### PR TITLE
install required packages to build the beegfs kernel module

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -38,6 +38,20 @@
   become: true
   notify: Restart BeeGFS client service
 
+- name: install dependencies to build kernel modules
+  block:
+    - name: install kernel-headers deb
+      apt:
+        name: "linux-headers-{{ ansible_kernel }}"
+        state: present
+      when: ansible_os_family == "Debian"
+    - name: install kernel-devel rpm
+      yum:
+        name: "kernel-devel-{{ ansible_kernel }}"
+        state: present
+      when: ansible_os_family == "RedHat"
+  become: true
+
 - name: Rebuild the BeeGFS client kernel module
   command: /etc/init.d/beegfs-client rebuild
   args:

--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -23,8 +23,8 @@
   apt:
     name: base-files
     state: present
-    update_cache: yes
-  become: yes 
+    update_cache: true
+  become: true
   when: ansible_os_family == "Debian"
 
 # Task flow inspired by MichaelRigart.interfaces role - thanks markgoddard
@@ -67,16 +67,16 @@
       service:
         name: beegfs-client
         state: stopped
-      become: yes
+      become: true
       when:
         - "'beegfs-client.service' in ansible_facts.services"
         - beegfs_enable.client | bool
-        - beegfs_enable.oss | bool      
+        - beegfs_enable.oss | bool
     - name: Stop BeeGFS server services
       service:
         name: "{{ item.name }}"
         state: stopped
-      become: yes
+      become: true
       when:
         - item.name in ansible_facts.services
         - item.enable | bool
@@ -88,10 +88,10 @@
       file:
         path: "{{ item.name }}"
         state: absent
-      become: yes
+      become: true
       when: item.enable | bool
       with_items:
-        - { name: "{{ beegfs_meta_path }}", enable: "{{ beegfs_enable.meta }}" } 
+        - { name: "{{ beegfs_meta_path }}", enable: "{{ beegfs_enable.meta }}" }
         - { name: "{{ beegfs_mgmt_path }}", enable: "{{ beegfs_enable.mgmt }}" }
   when: beegfs_force_format | bool
 

--- a/tasks/oss.yml
+++ b/tasks/oss.yml
@@ -41,7 +41,7 @@
         src: "{{ oss_dev }}"
         path: "{{ oss_path }}"
         state: unmounted
-      when: 
+      when:
         - oss_dev is defined
         - beegfs_force_format | bool
       notify: Restart BeeGFS storage service
@@ -68,7 +68,7 @@
         opts: "{{ beegfs_mount_opts }}"
       when: oss_dev is defined
       notify: Restart BeeGFS storage service
-  become: yes
+  become: true
 
 - name: Run storage service setup script
   command: |


### PR DESCRIPTION
install `linux-headers` in debian machines or `kernel-devel` in redhat machines so the beegfs kernel module can be compiled

also fix some lint warning reintroduced in https://github.com/stackhpc/ansible-role-beegfs/pull/17