### PR TITLE
added bool var add_beegfs_repos to define if repos are added or not

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,7 @@ beegfs_distro_vars:
       - "libbeegfs-ib"
 
 # BeeGFS repo
+add_beegfs_repos: true
 beegfs_repo_url: "{{ beegfs_distro_vars[ansible_os_family]['beegfs_repo_url'] }}"
 beegfs_repo_key: "{{ beegfs_distro_vars[ansible_os_family]['beegfs_repo_key'] }}"
 beegfs_repo_file: "{{ beegfs_distro_vars[ansible_os_family]['beegfs_repo_file'] }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,7 +47,7 @@ beegfs_distro_vars:
       - "libbeegfs-ib"
 
 # BeeGFS repo
-add_beegfs_repos: true
+beegfs_add_repos: true
 beegfs_repo_url: "{{ beegfs_distro_vars[ansible_os_family]['beegfs_repo_url'] }}"
 beegfs_repo_key: "{{ beegfs_distro_vars[ansible_os_family]['beegfs_repo_key'] }}"
 beegfs_repo_file: "{{ beegfs_distro_vars[ansible_os_family]['beegfs_repo_file'] }}"

--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -30,7 +30,7 @@
     become: true
     when: ansible_os_family == "Debian"
 
-  when: beegfs_add_repos | default(true) | bool
+  when: beegfs_add_repos
 
 # Task flow inspired by MichaelRigart.interfaces role - thanks markgoddard
 # Some systems do not support /etc/modules-load.d, in which case we fall back

--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -30,7 +30,7 @@
     become: true
     when: ansible_os_family == "Debian"
 
-  when: beegfs_add_repos
+  when: beegfs_add_repos | bool
 
 # Task flow inspired by MichaelRigart.interfaces role - thanks markgoddard
 # Some systems do not support /etc/modules-load.d, in which case we fall back

--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -1,5 +1,5 @@
 ---
-- name: Add BeeGFS repos is add_beegfs_repos is true
+- name: Add BeeGFS repos is beegfs_add_repos is true
   block:
 
   - name: Ensure the BeeGFS package repo is defined
@@ -30,7 +30,7 @@
     become: true
     when: ansible_os_family == "Debian"
 
-  when: add_beegfs_repos | default(true) | bool
+  when: beegfs_add_repos | default(true) | bool
 
 # Task flow inspired by MichaelRigart.interfaces role - thanks markgoddard
 # Some systems do not support /etc/modules-load.d, in which case we fall back

--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -1,31 +1,36 @@
 ---
-- name: Ensure the BeeGFS package repo is defined
-  get_url:
-    url: "{{ beegfs_repo_url }}"
-    dest: "{{ beegfs_repo_file }}"
-  become: true
-
-- name: Load package repo key
+- name: Add BeeGFS repos is add_beegfs_repos is true
   block:
-    - name: add apt key for debian family machines
-      apt_key:
-        state: present
-        url: "{{ beegfs_repo_key }}"
-      when: ansible_os_family == "Debian"
-    - name: add rpm key for redhat family machines
-      rpm_key:
-        state: present
-        key: "{{ beegfs_repo_key }}"
-      when: ansible_os_family == "RedHat"
-  become: true
 
-- name: Refresh apt repos
-  apt:
-    name: base-files
-    state: present
-    update_cache: true
-  become: true
-  when: ansible_os_family == "Debian"
+  - name: Ensure the BeeGFS package repo is defined
+    get_url:
+      url: "{{ beegfs_repo_url }}"
+      dest: "{{ beegfs_repo_file }}"
+    become: true
+
+  - name: Load package repo key
+    block:
+      - name: add apt key for debian family machines
+        apt_key:
+          state: present
+          url: "{{ beegfs_repo_key }}"
+        when: ansible_os_family == "Debian"
+      - name: add rpm key for redhat family machines
+        rpm_key:
+          state: present
+          key: "{{ beegfs_repo_key }}"
+        when: ansible_os_family == "RedHat"
+    become: true
+
+  - name: Refresh apt repos
+    apt:
+      name: base-files
+      state: present
+      update_cache: true
+    become: true
+    when: ansible_os_family == "Debian"
+
+  when: add_beegfs_repos | default(true) | bool
 
 # Task flow inspired by MichaelRigart.interfaces role - thanks markgoddard
 # Some systems do not support /etc/modules-load.d, in which case we fall back


### PR DESCRIPTION
this PR doesn't change the current default behaviour

repos will be added by default but you have the option to disable it in case you are providing the repos in a different way e.g. with your katello server

I did the molecule tests with centos and ubuntu and it's working fine for me
