### PR TITLE
stop and disable default storage service

### DIFF
--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -148,6 +148,14 @@
     - { name: beegfs-admon, enable: "{{ beegfs_enable.admon }}", state: started }
     - { name: beegfs-oss-tuning, enable: "{{ beegfs_enable.tuning }}" }
 
+- name: Stop and disable default BeeGFS storage services (not used)
+  service:
+    name: beegfs-storage
+    enabled: false
+    state: stopped
+  become: true
+  when: beegfs_enable.oss | bool
+
 - name: Start and enable BeeGFS storage services
   service:
     name: "beegfs-storage@{{ item.port }}"


### PR DESCRIPTION
after running the role I was getting this in the oss servers

```
[root@oss01 vagrant]# systemctl |grep -i beegfs
  data-beegfs-beegfs_oss-dev-sdb.mount                                                     loaded active mounted   /data/beegfs/beegfs_oss/dev/sdb
  data-beegfs-beegfs_oss-dev-sdc.mount                                                     loaded active mounted   /data/beegfs/beegfs_oss/dev/sdc
  beegfs-oss-tuning.service                                                                loaded active exited    BeeGFS Tuning Service
● beegfs-storage.service                                                                   loaded failed failed    BeeGFS Storage Server
  beegfs-storage@8003.service                                                              loaded active running   BeeGFS Storage Server (multimode)
  system-beegfs\x2dstorage.slice                                                           loaded active active    system-beegfs\x2dstorage.slice
```

notice the line ` beegfs-storage.service loaded failed failed `

the default storage service is started but not used. This task should stop and disable it