### PR TITLE
Make the role more resilient to path only oss (v19.8.1)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,7 +67,7 @@ beegfs_oss:
   - port: 8003
     dev: "/dev/sdb"
     path:  # specifying dev overrides path
-beegfs_oss_tunable: "{{ beegfs_oss | map(attribute='dev') | map('relpath', '/dev/' ) | list }}"
+beegfs_oss_tunable: "{{ beegfs_oss | selectattr('dev', 'defined') | map(attribute='dev') | map('relpath', '/dev/' ) | list }}"
 # Whether to support multiple ports per OSS:
 # - if this is set to false, make sure that you configure the ports to the same
 #   value when passing beegfs_oss as an input.

--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -117,13 +117,16 @@
 
 - include: oss.yml
   vars:
-    oss_replace: "{{ '-r' if (oss_item == beegfs_oss|first or beegfs_oss_multi_port) else '' }}"
-    oss_path: "{{ oss_item.path | default(beegfs_oss_path_prefix + oss_item.dev) }}"
+    oss_dev: "{{ oss_item.dev | default('') }}"
+    oss_dev_is_defined: "{{ oss_item.dev is defined }}"
+    oss_path: "{{ oss_item.path | default(beegfs_oss_path_prefix + oss_dev) }}"
     oss_port: "{{ oss_item.port }}"
-    oss_dev: "{{ oss_item.dev | default(omit) }}"
+    oss_replace: "{{ '-r' if (oss_item == beegfs_oss|first or beegfs_oss_multi_port) else '' }}"
   with_items: "{{ beegfs_oss }}"
   loop_control:
     loop_var: oss_item
+  failed_when: >
+    (oss_item.dev is not defined and oss_item.path is not defined)
   when: beegfs_enable.oss | default(false) | bool
 
 - include: tuning.yml

--- a/tasks/destroy.yml
+++ b/tasks/destroy.yml
@@ -24,7 +24,9 @@
     enabled: false
     state: stopped
   become: true
-  when: beegfs_enable.oss | bool
+  when:
+    - beegfs_enable.oss | bool
+    - item.dev is defined
   with_items: "{{ beegfs_oss }}"
 
 - name: Stop and disable BeeGFS storage services

--- a/tasks/oss.yml
+++ b/tasks/oss.yml
@@ -33,9 +33,7 @@
         src: "{{ oss_dev }}"
         path: "{{ oss_path }}"
         state: unmounted
-      when:
-        - oss_dev is defined
-        - beegfs_force_format | bool
+      when: beegfs_force_format | bool
       notify: Restart BeeGFS storage service
     - name: Attempt to format if the device is not mounted or if beegfs_force_format is true
       filesystem:
@@ -43,9 +41,7 @@
         fstype: "{{ beegfs_fstype }}"
         force: "{{ beegfs_force_format | bool }}"
         opts: "{{ beegfs_filesystem_opts }}"
-      when:
-        - oss_dev is defined
-        - (oss_dev not in mounted_devs) or (beegfs_force_format | bool)
+      when: (oss_dev not in mounted_devs) or (beegfs_force_format | bool)
       notify: Restart BeeGFS storage service
     - name: Ensure the mount point exists
       file:
@@ -58,9 +54,9 @@
         fstype: "{{ beegfs_fstype }}"
         state: mounted
         opts: "{{ beegfs_mount_opts }}"
-      when: oss_dev is defined
       notify: Restart BeeGFS storage service
   become: true
+  when: oss_dev_is_defined
 
 - name: Run storage service setup script
   command: |


### PR DESCRIPTION
At present, our support for path only oss (defined as item.dev) is not
very reliable. This PR aims to address this my fixing the various holes.

Fixes #46