### PR TITLE
Separate disk tuning from system tuning (v19.8.2)

### DIFF
--- a/tasks/tuning.yml
+++ b/tasks/tuning.yml
@@ -29,5 +29,4 @@
         src: beegfs-oss-tuning.service
         dest: /etc/systemd/system/
       notify: Restart BeeGFS tuning service
-  when: beegfs_oss_tunable | default([]) | length > 0
   become: true

--- a/templates/beegfs-oss-tuning.sh.j2
+++ b/templates/beegfs-oss-tuning.sh.j2
@@ -5,6 +5,7 @@ set -x
 
 echo always > /sys/kernel/mm/transparent_hugepage/enabled
 echo always > /sys/kernel/mm/transparent_hugepage/defrag
+{% if beegfs_oss_tunable | length > 0 %}
 for dev in {{ beegfs_oss_tunable | join(' ') }}
 do
   if [ -d /sys/block/${dev} ]; then
@@ -14,3 +15,4 @@ do
     echo 256 > /sys/block/${dev}/queue/max_sectors_kb
   fi
 done
+{% endif %}


### PR DESCRIPTION
At present, when tuning is enabled, the role assumes that all oss paths
are block devices. This leads to failure in some cases. This patch
attempts to separate the logic.