### PR TITLE
Use source of symlinked OSS devices

### DIFF
--- a/tasks/destroy.yml
+++ b/tasks/destroy.yml
@@ -62,7 +62,7 @@
 
 - name: Unmount BeeGFS oss paths if mounted
   vars:
-    oss_path: "{{ beegfs_oss_path_prefix + item.dev }}"
+    oss_path: "{{ item.path | default(beegfs_oss_path_prefix + item.dev) }}"
   mount:
     path: "{{ oss_path }}"
     state: unmounted

--- a/tasks/oss.yml
+++ b/tasks/oss.yml
@@ -28,6 +28,14 @@
 
 - name: Prepare storage devices
   block:
+    - name: Stat the OSS device
+      stat:
+        path: "{{ oss_dev }}"
+      register: oss_dev_stat
+    - name: Fail if OSS device does not exist
+      fail:
+        msg: OSS device {{ oss_dev }} does not exist
+      when: not oss_dev_stat.exists
     - name: Unmount storage device if beegfs_force_format is true
       mount:
         src: "{{ oss_dev }}"
@@ -36,12 +44,14 @@
       when: beegfs_force_format | bool
       notify: Restart BeeGFS storage service
     - name: Attempt to format if the device is not mounted or if beegfs_force_format is true
+      vars:
+        oss_dev_real: "{{ oss_dev_stat.lnk_source if oss_dev_stat.islnk else oss_dev_stat.path }}"
       filesystem:
         dev: "{{ oss_dev }}"
         fstype: "{{ beegfs_fstype }}"
         force: "{{ beegfs_force_format | bool }}"
         opts: "{{ beegfs_filesystem_opts }}"
-      when: (oss_dev not in mounted_devs) or (beegfs_force_format | bool)
+      when: (oss_dev_real not in mounted_devs) or (beegfs_force_format | bool)
       notify: Restart BeeGFS storage service
     - name: Ensure the mount point exists
       file:

--- a/tasks/oss.yml
+++ b/tasks/oss.yml
@@ -38,7 +38,6 @@
       when: not oss_dev_stat.exists
     - name: Unmount storage device if beegfs_force_format is true
       mount:
-        src: "{{ oss_dev }}"
         path: "{{ oss_path }}"
         state: unmounted
       when: beegfs_force_format | bool


### PR DESCRIPTION
If you set the dev attribute of one of the OSS devices to a symlink in
/dev/disk/ e.g. /dev/disk/by-id/<id>, then run the role with the file
system already mounted, the following task fails:

TASK [roles/stackhpc.beegfs : Attempt to format if the device is not
mounted or if beegfs_force_format is true]

mkfs.xfs: cannot open /dev/disk/by-path/pci-0000:18:00.0-sas-phy4-lun-0:
Device or resource busy

This is because the task runs only if the device is not mounted, but the
symlink source is displayed in the mount list rather than the target.

This commit changes to use the source of the link when checking the list
of mounted devices.

We also introduce a check for the existence of the device, and fail if
it does not exist.

Fixes: #50