### PR TITLE
Umount meta data device only in case of reformat

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,8 @@ beegfs_mgmt_host:  # Example: "{{ groups['cluster_beegfs_mgmt'] | first }}"
 beegfs_meta_path: "/data/beegfs/beegfs_meta"
 beegfs_meta_dev:  # /dev/sdb
 beegfs_meta_fstype:  # Example: "ext4"
+beegfs_meta_filesystem_opts: "-i 2048 -I 512 -J size=400 -O dir_index,filetype"
+beegfs_meta_mount_opts: "noatime,nodiratime,nobarrier,auto"
 
 # Client mount configs
 beegfs_client: []
@@ -96,4 +98,10 @@ beegfs_package_action: "{{ 'latest' if beegfs_update | bool else 'present' }}"
 
 # Path to the kernel module
 beegfs_kernel_module: "/lib/modules/{{ ansible_kernel }}/updates/fs/beegfs_autobuild/beegfs.ko"
+
+# tuneNumWorkers settings for meta server
+beegfs_meta_tuneNumWorkers: 0
+
+# tuneNumWorkers settings for meta server
+beegfs_meta_tuneTargetChooser: randomized
 ...

--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -91,6 +91,16 @@
         state: stopped
       with_items: "{{ beegfs_oss }}"
       when: service_name in ansible_facts.services
+
+    - name: Ensure meta device is not currently mounted
+      mount:
+        path: "{{ beegfs_meta_path }}"
+        state: unmounted
+      when:
+        - beegfs_enable.meta | default(false) | bool
+        - beegfs_meta_dev is defined
+        - beegfs_meta_dev != None
+
     - name: Remove other beegfs folders
       file:
         path: "{{ item.name }}"

--- a/tasks/destroy.yml
+++ b/tasks/destroy.yml
@@ -84,6 +84,16 @@
     - beegfs_enable.oss | bool
     - item.dev is defined
 
+- name: Ensure meta device is not currently mounted
+  become: true
+  mount:
+    path: "{{ beegfs_meta_path }}"
+    state: unmounted
+  when:
+    - beegfs_enable.meta | default(false) | bool
+    - beegfs_meta_dev is defined
+    - beegfs_meta_dev != None
+
 - name: Remove other beegfs folders
   file:
     path: "{{ item.name }}"

--- a/tasks/meta.yml
+++ b/tasks/meta.yml
@@ -15,17 +15,13 @@
 
 - name: Prepare metadata block storage
   block:
-    - name: Ensure storage device is not currently mounted
-      mount:
-        path: "{{ beegfs_meta_path }}"
-        state: unmounted
-      notify: Restart BeeGFS meta service
     - name: Format filesystem
       vars:
         meta_fstype: "{{ beegfs_meta_fstype | default(beegfs_fstype) }}"
       filesystem:
         dev: "{{ beegfs_meta_dev }}"
         fstype: "{{ meta_fstype }}"
+        opts: "{{ beegfs_meta_filesystem_opts }}"
         force: "{{ beegfs_force_format }}"
       notify: Restart BeeGFS meta service
     - name: Mount filesystem
@@ -35,6 +31,7 @@
         src: "{{ beegfs_meta_dev }}"
         path: "{{ beegfs_meta_path }}"
         fstype: "{{ meta_fstype }}"
+        opts: "{{ beegfs_meta_mount_opts }}"
         state: mounted
       notify: Restart BeeGFS meta service
   become: true
@@ -54,6 +51,22 @@
     path: /etc/beegfs/beegfs-meta.conf
     regexp: "^connInterfacesFile"
     line: "connInterfacesFile           = /etc/beegfs/connInterfacesFile"
+  become: true
+  notify: Restart BeeGFS meta service
+
+- name: Modify tuneTargetChooser settings
+  lineinfile:
+    path: /etc/beegfs/beegfs-meta.conf
+    regexp: "^tuneTargetChooser"
+    line: "tuneTargetChooser            = {{ beegfs_meta_tuneTargetChooser }}"
+  become: true
+  notify: Restart BeeGFS meta service
+
+- name: Modify tuneNumWorkers settings
+  lineinfile:
+    path: /etc/beegfs/beegfs-meta.conf
+    regexp: "^tuneNumWorkers"
+    line: "tuneNumWorkers               = {{ beegfs_meta_tuneNumWorkers }}"
   become: true
   notify: Restart BeeGFS meta service
 ...

--- a/tasks/oss.yml
+++ b/tasks/oss.yml
@@ -35,7 +35,7 @@
     - name: Fail if OSS device does not exist
       fail:
         msg: OSS device {{ oss_dev }} does not exist
-      when: not oss_dev_stat.exists
+      when: not oss_dev_stat.stat.exists
     - name: Unmount storage device if beegfs_force_format is true
       mount:
         path: "{{ oss_path }}"
@@ -44,7 +44,7 @@
       notify: Restart BeeGFS storage service
     - name: Attempt to format if the device is not mounted or if beegfs_force_format is true
       vars:
-        oss_dev_real: "{{ oss_dev_stat.lnk_source if oss_dev_stat.islnk else oss_dev_stat.path }}"
+        oss_dev_real: "{{ oss_dev_stat.stat.lnk_source if oss_dev_stat.stat.islnk else oss_dev_stat.stat.path }}"
       filesystem:
         dev: "{{ oss_dev }}"
         fstype: "{{ beegfs_fstype }}"

--- a/templates/beegfs-oss-tuning.sh.j2
+++ b/templates/beegfs-oss-tuning.sh.j2
@@ -12,7 +12,18 @@ do
     echo mq-deadline > /sys/block/${dev}/queue/scheduler
     echo 2048 > /sys/block/${dev}/queue/nr_requests
     echo 4096 > /sys/block/${dev}/queue/read_ahead_kb
-    echo 256 > /sys/block/${dev}/queue/max_sectors_kb
+    echo {{ dev.max_sectors_kb | default("256") }} > /sys/block/${dev}/queue/max_sectors_kb
   fi
 done
+{% endif %}
+
+
+{% if beegfs_meta_dev and beegfs_meta_tunings %}
+dev={{beegfs_meta_dev | relpath('/dev/') }}
+ if [ -d /sys/block/${dev} ]; then
+    echo mq-deadline > /sys/block/${dev}/queue/scheduler
+    echo 128 > /sys/block/${dev}/queue/nr_requests
+    echo 128 > /sys/block/${dev}/queue/read_ahead_kb
+    echo 256 > /sys/block/${dev}/queue/max_sectors_kb
+  fi
 {% endif %}


### PR DESCRIPTION
Prior to this change, running the playbook a second time will not work
because the meta.yml playbook will try to unmount the meta data device
while the service is still running and also it is unnecessary.
Additionally add explicit filesystem and mount options for the metadata
devices.
Small bugfix for newer ansbile file module. 
Enable optional meta data device tunings for devices and service.