### PR TITLE
prevent stat module error, and change kernel package name to fit OL7.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ beegfs_distro_vars:
     beegfs_repo_url: "https://www.beegfs.io/release/latest-stable/dists/beegfs-rhel7.repo"
     beegfs_repo_key: "https://www.beegfs.io/release/latest-stable/gpg/RPM-GPG-KEY-beegfs"
     beegfs_repo_file: "/etc/yum.repos.d/beegfs-rhel7.repo"
-    kernel_dev_pkg: "kernel-devel"
+    kernel_dev_pkg: "kernel-uek-devel"
     rdma_dev_pkgs:
       - "librdmacm"
       - "libibmad"
@@ -57,7 +57,8 @@ beegfs_rdma: true
 
 # Default filesystem options
 beegfs_filesystem_opts: "-K -d su=128k,sw=8 -l version=2,su=128k -isize=512"
-beegfs_mount_opts: "noatime,nodiratime,logbufs=8,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k,nobarrier"
+#beegfs_mount_opts: "noatime,nodiratime,logbufs=8,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k,nobarrier"
+beegfs_mount_opts: "noatime,nodiratime,logbufs=8,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"
 beegfs_force_format: false
 beegfs_fstype: "xfs"
 

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -17,7 +17,7 @@
     line: "{{ item.line }}"
   when: item.condition
   with_items:
-    - { line: "buildArgs=-j8 BEEGFS_OPENTK_IBVERBS=1", condition: "{{ beegfs_rdma | bool }}" }
+    - { line: "buildArgs=-j8 BEEGFS_OPENTK_IBVERBS=1 OFED_INCLUDE_PATH=/usr/src/ofa_kernel/default/include/", condition: "{{ beegfs_rdma | bool }}" }
     - { line: "buildArgs=-j8", condition: "{{ not beegfs_rdma | bool }}" }
   notify: Restart BeeGFS client service
   become: true

--- a/tasks/oss.yml
+++ b/tasks/oss.yml
@@ -35,7 +35,7 @@
     - name: Fail if OSS device does not exist
       fail:
         msg: OSS device {{ oss_dev }} does not exist
-      when: not oss_dev_stat.exists
+      when: not oss_dev_stat.stat.exists
     - name: Unmount storage device if beegfs_force_format is true
       mount:
         path: "{{ oss_path }}"
@@ -44,7 +44,7 @@
       notify: Restart BeeGFS storage service
     - name: Attempt to format if the device is not mounted or if beegfs_force_format is true
       vars:
-        oss_dev_real: "{{ oss_dev_stat.lnk_source if oss_dev_stat.islnk else oss_dev_stat.path }}"
+        oss_dev_real: "{{ oss_dev_stat.stat.lnk_source if oss_dev_stat.stat.islnk else oss_dev_stat.stat.path }}"
       filesystem:
         dev: "{{ oss_dev }}"
         fstype: "{{ beegfs_fstype }}"

--- a/templates/beegfs-oss-tuning.sh.j2
+++ b/templates/beegfs-oss-tuning.sh.j2
@@ -12,7 +12,7 @@ do
     echo mq-deadline > /sys/block/${dev}/queue/scheduler
     echo 2048 > /sys/block/${dev}/queue/nr_requests
     echo 4096 > /sys/block/${dev}/queue/read_ahead_kb
-    echo 256 > /sys/block/${dev}/queue/max_sectors_kb
+#    echo 256 > /sys/block/${dev}/queue/max_sectors_kb
   fi
 done
 {% endif %}


### PR DESCRIPTION
I encountered 3 errors when I use your role on Oracle Cloud (Oracle Linux  7.9) with ansible 2.10.5

1. oss_dev_stat has no attributes 'path', 'islnk', 'exists', and 'lnk_source'.
2. unknown mount option 'nobarrier'.
3. no package matching 'kernel-devel-...'

3rd is OL7 specific issue, but 1st & 2nd may be common issue.
